### PR TITLE
Update Caddy and Convex configurations to use 'starter-' prefix for d…

### DIFF
--- a/apps/caddy/Caddyfile
+++ b/apps/caddy/Caddyfile
@@ -1,7 +1,7 @@
-convex-dashboard.reelfreakz.com {
+starter-convex-dashboard.reelfreakz.com {
     reverse_proxy dashboard:6791
 }
 
-convex-backend.reelfreakz.com {
+starter-convex-backend.reelfreakz.com {
     reverse_proxy backend:3210
 }

--- a/apps/caddy/README.md
+++ b/apps/caddy/README.md
@@ -16,8 +16,8 @@ Caddy is configured to act as a reverse proxy for the following domains:
 
 | Domain | Backend Service |
 | :--- | :--- |
-| `convex-dashboard.reelfreakz.com` | Proxies to `dashboard:6791` |
-| `convex-backend.reelfreakz.com` | Proxies to `backend:3210` |
+| `starter-convex-dashboard.reelfreakz.com` | Proxies to `dashboard:6791` |
+| `starter-convex-backend.reelfreakz.com` | Proxies to `backend:3210` |
 
 ## 🚀 Running Caddy
 
@@ -39,7 +39,7 @@ To route traffic correctly, you must configure the following **A records** in yo
 
 | Type | Name | Content | Proxy Status | TTL |
 | :--- | :--- | :--- | :--- | :--- |
-| `A` | `convex-backend` | `122.166.57.113` | DNS only | Auto |
-| `A` | `convex-dashboard` | `122.166.57.113` | DNS only | Auto |
+| `A` | `starter-convex-backend` | `122.166.57.113` | DNS only | Auto |
+| `A` | `starter-convex-dashboard` | `122.166.57.113` | DNS only | Auto |
 
 > **Note:** Set the Proxy Status to **DNS only** (Grey Cloud) to allow Caddy to manage SSL certificates automatically.

--- a/apps/convex/README.md
+++ b/apps/convex/README.md
@@ -28,12 +28,12 @@ convex-self-hosted|xxx
 
 When prompted by the dashboard, use the following details:
 
-- **Deployment URL**: `https://convex-backend.reelfreakz.com`
+- **Deployment URL**: `https://starter-convex-backend.reelfreakz.com`
 - **Admin Key**: The key you generated above.
 
 ## 🌐 Important URLs
 
 | Service | URL |
 | :--- | :--- |
-| **Dashboard** | [https://convex-dashboard.reelfreakz.com/](https://convex-dashboard.reelfreakz.com/) |
-| **Backend** | [https://convex-backend.reelfreakz.com](https://convex-backend.reelfreakz.com) |
+| **Dashboard** | [https://starter-convex-dashboard.reelfreakz.com/](https://starter-convex-dashboard.reelfreakz.com/) |
+| **Backend** | [https://starter-convex-backend.reelfreakz.com](https://starter-convex-backend.reelfreakz.com) |


### PR DESCRIPTION
…omains

- Changed domain names in Caddyfile and README to reflect the new 'starter-' prefix for both dashboard and backend services.
- Updated deployment URL and important URLs in Convex README to match the new domain structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated domain configurations and documentation for backend and dashboard services. Endpoint URLs have been modified across deployment and configuration files to reflect new domain names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->