### PR TITLE
feat: add scripts to start and stop worker service independently

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,6 +24,26 @@
         "reveal": "always",
         "panel": "dedicated"
       }
+    },
+    {
+      "label": "Docker: Start Worker",
+      "type": "shell",
+      "command": "./scripts/start-worker.sh",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      }
+    },
+    {
+      "label": "Docker: Stop Worker",
+      "type": "shell",
+      "command": "./scripts/stop-worker.sh",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      }
     }
   ]
 }

--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Get the directory where the script is located, then go up one level to root
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+NETWORK_NAME="turborepo-astro-starter-network"
+if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
+  echo "Creating network: $NETWORK_NAME..."
+  docker network create "$NETWORK_NAME"
+fi
+
+echo "Building and starting Worker service..."
+docker compose -f "$REPO_ROOT/apps/worker/docker-compose.yml" up -d --build
+
+echo "Worker service started successfully!"

--- a/scripts/stop-worker.sh
+++ b/scripts/stop-worker.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Get the directory where the script is located, then go up one level to root
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "Stopping Worker service..."
+docker compose -f "$REPO_ROOT/apps/worker/docker-compose.yml" down
+
+echo "Worker service stopped successfully!"


### PR DESCRIPTION
## Summary

This PR adds dedicated scripts to manage the worker service independently, following the same pattern as the existing Docker management scripts.

## Key Changes

- **Added `scripts/start-worker.sh`**: Script to start only the worker service with Docker network creation check
- **Added `scripts/stop-worker.sh`**: Script to stop only the worker service
- **Updated `.vscode/tasks.json`**: Added two new VS Code tasks:
  - "Docker: Start Worker" - runs `./scripts/start-worker.sh`
  - "Docker: Stop Worker" - runs `./scripts/stop-worker.sh`

## Implementation Details

- Both scripts follow the same pattern as `start-docker.sh` and `stop-docker.sh`
- The start script ensures the Docker network (`turborepo-astro-starter-network`) exists before starting
- Uses `--build` flag to ensure the worker image is built when starting
- VS Code tasks use the same presentation settings (reveal: always, panel: dedicated) as existing Docker tasks

## Testing

- ✅ Scripts are executable
- ✅ Linting passed (`pnpm lint`)
- ✅ Formatting passed (`pnpm format`)
- ✅ Scripts follow the established pattern from existing Docker scripts

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added two new VSCode tasks enabling quick Docker worker service start and stop operations.
  * Introduced automated worker service management scripts with built-in Docker network provisioning and error handling for improved developer workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->