### PR TITLE
feat: add README changelog update step to create-pr command

### DIFF
--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -31,13 +31,34 @@ Follow these steps carefully:
 - Use the **Conventional Commits** format (e.g., `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`).
 - Keep the summary line under 50 characters and provide a body if the changes are complex.
 
-### 5. Commit & Push
+### 5. Update README Files with Changelog
 
-- If changes are not staged, run `git add .`.
+- After generating the commit message (Step 4), analyze the git diff to identify which README files need updating:
+  - Check if changes affect root-level files → update `README.md`
+  - Check if changes affect files in `apps/<app-name>/` → update `apps/<app-name>/README.md`
+  - Check if changes affect files in `packages/<package-name>/` → update `packages/<package-name>/README.md` (if it exists)
+- For each README that needs updating:
+  - Read the current README file
+  - Analyze the git diff to extract meaningful changes (features added, bugs fixed, dependencies updated, etc.)
+  - Generate a changelog entry in **Conventional Commits** format with:
+    - Date (current date in YYYY-MM-DD format)
+    - Type prefix (feat, fix, chore, refactor, docs, etc.) matching the commit message
+    - Brief description of the change
+  - Add the changelog entry to a "## Changelog" section:
+    - If the section doesn't exist, create it at the end of the README (before "## Learn More" if present, or at the end)
+    - If it exists, prepend the new entry at the top of the changelog section
+    - Format: `### YYYY-MM-DD` followed by bullet points with `- **Type**: Description`
+- Stage the updated README files: `git add <path-to-readme>`
+- If no README files exist for affected directories, skip silently
+
+### 6. Commit & Push
+
+- Note that README files are already staged from Step 5.
+- If changes are not staged, run `git add .` as a fallback for any other unstaged changes.
 - Commit the changes using the generated message: `git commit -m "<message>"`.
 - Push the new branch to origin with upstream tracking: `git push -u origin fix/issue-<number>`.
 
-### 6. Create Pull Request
+### 7. Create Pull Request
 
 - Generate a PR title from the commit summary.
 - Generate a detailed PR description including:
@@ -56,7 +77,7 @@ Follow these steps carefully:
 - Display the PR URL as a clickable markdown hyperlink: `[<PR Title>](<PR_URL>)`.
 - Also display the raw URL for reference.
 
-### 7. Error Handling
+### 8. Error Handling
 
 - If any command fails, stop and explain the error to the user.
 - If fetching the default branch fails, stop and inform the user to check their network connection and repository access.
@@ -64,3 +85,7 @@ Follow these steps carefully:
 - If creating or checking out the new branch fails, stop and explain the error to the user.
 - If there are merge conflicts when pushing, inform the user they need to resolve them manually.
 - If the issue number is not provided or invalid, stop and inform the user that a valid issue number is required.
+- For README update operations (Step 5):
+  - If reading a README file fails, log a warning but continue (don't stop the process)
+  - If writing a README file fails, stop and inform the user
+  - If the README file is read-only or has permission issues, inform the user

--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ To use the shared configuration in a new app:
    export default [...astroConfig];
    ```
 
+## Changelog
+
+### 2026-01-17
+
+- **feat**: Added README changelog update step to create-pr command
+
 ## Learn More
 
 - [Turborepo Documentation](https://turbo.build/repo/docs)


### PR DESCRIPTION
## Summary

This PR adds a new step to the create-pr command that automatically updates README files with changelog entries based on git diff before committing changes.

## Key Changes

- Added new Step 5: "Update README Files with Changelog" that:
  - Analyzes git diff to identify which README files need updating (root, apps, packages)
  - Generates changelog entries in Conventional Commits format
  - Adds entries to a "## Changelog" section (creates if missing, prepends if exists)
  - Stages updated README files automatically
- Renumbered existing steps 5-7 to become steps 6-8
- Updated Commit & Push step to reference README staging from previous step
- Enhanced error handling for README update operations

## Testing

- Verified linting passes (`pnpm lint`)
- Verified formatting passes (`pnpm format`)
- Tested the command workflow manually

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR creation process to automatically analyze and update relevant README files with generated changelog entries.
  * Implemented comprehensive error handling for README operations, including permission validation and user-friendly error notifications.
  * Added changelog section to main README documenting recent project updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->