### PR TITLE
chore: remove port bindings from docker-compose files

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ To use the shared configuration in a new app:
 
 ### 2026-01-17
 
+- **chore**: Removed port bindings from docker-compose.yml files for all services (backend, dashboard, worker)
 - **feat**: Added README changelog update step to create-pr command
 
 ## Learn More

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -59,3 +59,9 @@ CONVEX_URL="https://starter-convex-backend.reelfreakz.com"
 
 > **Note:** Replace `convex-self-hosted|xxxx` with your actual admin key.  
 > Always enclose values in double quotes to avoid parsing errors.
+
+## Changelog
+
+### 2026-01-17
+
+- **chore**: Removed port bindings from docker-compose.yml for starter-backend and starter-dashboard services

--- a/apps/backend/docker-compose.yml
+++ b/apps/backend/docker-compose.yml
@@ -4,9 +4,6 @@ services:
     image: ghcr.io/get-convex/convex-backend:aef0568827a4d1b9a3a6a8c45653567af54b59b9
     stop_grace_period: 10s
     stop_signal: SIGINT
-    ports:
-      - "${PORT:-3210}:3210"
-      - "${SITE_PROXY_PORT:-3211}:3211"
     volumes:
       - /var/lib/turborepo-astro-starter/convex-data:/convex/data
 
@@ -23,8 +20,6 @@ services:
     image: ghcr.io/get-convex/convex-dashboard:aef0568827a4d1b9a3a6a8c45653567af54b59b9
     stop_grace_period: 10s
     stop_signal: SIGINT
-    ports:
-      - "${DASHBOARD_PORT:-6791}:6791"
     depends_on:
       starter-backend:
         condition: service_healthy

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -22,3 +22,9 @@ If everything is working, you'll receive a response from the worker service.
 - For more endpoints or advanced usage, check the service's API documentation.
 
 Enjoy automating with our Worker! 😊
+
+## Changelog
+
+### 2026-01-17
+
+- **chore**: Removed port bindings from docker-compose.yml for starter-worker service

--- a/apps/worker/docker-compose.yml
+++ b/apps/worker/docker-compose.yml
@@ -3,8 +3,6 @@ services:
     build:
       context: ../../
       dockerfile: apps/worker/Dockerfile
-    ports:
-      - "${WORKER_PORT:-3001}:3001"
     networks:
       - turborepo-astro-starter-network
     restart: unless-stopped


### PR DESCRIPTION
## Summary

This PR removes port bindings from all docker-compose.yml files for services that communicate internally via Docker network.

## Key Changes

- Removed `ports` section from `starter-backend` service in `apps/backend/docker-compose.yml`
- Removed `ports` section from `starter-dashboard` service in `apps/backend/docker-compose.yml`
- Removed `ports` section from `starter-worker` service in `apps/worker/docker-compose.yml`

## Testing

- All services remain on the same Docker network (`turborepo-astro-starter-network`)
- Services can communicate internally without exposing ports to the host machine
- This follows best practices for containerized applications where services only need internal communication

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed explicit port mappings from docker-compose configurations for backend, dashboard, and worker services.

* **Documentation**
  * Updated service changelogs documenting configuration changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->