### PR TITLE
feat: add duration display to start-worker.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ To use the shared configuration in a new app:
 
 ### 2026-01-17
 
+- **feat**: Added duration display to start-worker.sh script to track container startup time
 - **chore**: Removed port bindings from docker-compose.yml files for all services (backend, dashboard, worker)
 - **feat**: Added README changelog update step to create-pr command
 

--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Capture start time for duration measurement
+START_TIME=$(date +%s.%N)
+
 # Get the directory where the script is located, then go up one level to root
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -13,4 +16,9 @@ fi
 echo "Building and starting Worker service..."
 docker compose -f "$REPO_ROOT/apps/worker/docker-compose.yml" up -d --build
 
+# Capture end time and calculate duration
+END_TIME=$(date +%s.%N)
+DURATION=$(echo "$END_TIME - $START_TIME" | bc)
+
 echo "Worker service started successfully!"
+printf "Total duration: %.2f seconds\n" "$DURATION"


### PR DESCRIPTION
## Summary

This PR adds timing measurement functionality to the `start-worker.sh` script to track and display the total duration it takes to start containers.

## Key Changes

- Added start time capture using `date +%s.%N` for high-precision timing (nanoseconds)
- Added end time capture after Docker Compose completes successfully
- Calculated duration using `bc` for floating-point arithmetic
- Display duration in human-readable format with 2 decimal places (e.g., "Total duration: 12.34 seconds")

## Testing

The script has been validated with:
- `pnpm lint` - All linting checks passed
- `pnpm format` - Code formatting verified

The timing includes:
- Network creation (if needed)
- Docker image build time
- Container startup time

## Example Output

```
Building and starting Worker service...
Worker service started successfully!
Total duration: 12.34 seconds
```

Closes #26