### PR TITLE
feat: add Dockerfile validation rule for cursor

### DIFF
--- a/.cursor/rules/dockerfile-validation.mdc
+++ b/.cursor/rules/dockerfile-validation.mdc
@@ -1,0 +1,38 @@
+---
+description: Build and validate Docker images when Dockerfile changes are made
+globs:
+  - "**/Dockerfile"
+  - "**/Dockerfile.*"
+  - "**/docker-compose.yml"
+---
+
+# Dockerfile Validation Rule
+
+Whenever a Dockerfile or docker-compose.yml is modified, **always** build the Docker image to validate that the changes work correctly.
+
+## Steps to Follow
+
+1. **Identify the Dockerfile location**
+   - Determine which Dockerfile was modified
+   - Check if there's an associated docker-compose.yml file
+
+2. **Build the Docker image**
+   - For `apps/worker/Dockerfile`: Use `docker compose -f apps/worker/docker-compose.yml build`
+   - For other Dockerfiles: Use `docker build` with appropriate context and dockerfile path
+   - Always run from the repository root
+
+3. **Validate the build**
+   - Check that the build completes successfully (exit code 0)
+   - If build fails, report the error and stop
+   - If build succeeds, continue with normal workflow
+
+## Build Commands
+
+- **Worker service:** `docker compose -f apps/worker/docker-compose.yml build`
+- **Generic Dockerfile:** `docker build -f <path-to-dockerfile> -t <image-name> <context-path>`
+
+## Important Notes
+
+- Build validation must happen **after** Dockerfile changes
+- Do not skip validation even if other tasks are pending
+- Build failures should be reported clearly with error output

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ To use the shared configuration in a new app:
 
 ### 2026-01-17
 
+- **feat**: Add Dockerfile validation rule for cursor to build and validate Docker images when Dockerfile changes are made
 - **fix**: Add close property to VS Code tasks to automatically close terminals after completion
 - **perf**: Optimized worker Docker build with turbo prune for improved caching and faster rebuilds
 - **feat**: Added duration display to start-worker.sh script to track container startup time


### PR DESCRIPTION
## Summary

This PR adds a cursor rule that automatically builds and validates Docker images whenever Dockerfile or docker-compose.yml files are modified. This ensures Docker builds succeed before proceeding with other changes.

## Key Changes

- Created `.cursor/rules/dockerfile-validation.mdc` rule file
- Rule triggers on changes to `**/Dockerfile`, `**/Dockerfile.*`, and `**/docker-compose.yml` files
- Provides build commands for different scenarios:
  - Worker service: uses `docker compose -f apps/worker/docker-compose.yml build`
  - Generic Dockerfiles: uses `docker build` with appropriate context
- Validates build success (exit code 0) before continuing
- Updated README changelog with this feature

## Testing

- Verified the rule file was created correctly
- Ran `pnpm lint` and `pnpm format` - all checks passed
- Pre-commit hooks executed successfully

Closes #30