### PR TITLE
chore: remove pnpm lint from husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,2 @@
 #!/bin/sh
 pnpm format:check
-pnpm lint

--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ To use the shared configuration in a new app:
 
 ## Changelog
 
+### 2026-01-27
+
+- **chore**: remove pnpm lint from husky pre-commit hook
+
 ### 2026-01-26
 
 - **feat**: Add Cloudflare R2 file upload support to desktop app


### PR DESCRIPTION
## Summary
This PR removes the `pnpm lint` command from the Husky pre-commit hook to speed up the commit process.

## Key Changes
- Removed `pnpm lint` from `.husky/pre-commit`.
- Updated `README.md` with the changelog entry.

## Testing
- Verified that `pnpm format:check` still runs during commit.
- Manually ran `pnpm lint` to ensure it still works as expected.

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined pre-commit configuration to improve developer workflow efficiency by adjusting automated checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->