### PR TITLE
feat: add worker docker CI/CD workflow with commit SHA tagging

### DIFF
--- a/.github/workflows/worker-docker.yml
+++ b/.github/workflows/worker-docker.yml
@@ -1,0 +1,57 @@
+name: Worker Docker CI/CD
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/worker/**"
+      - "packages/math/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/worker-docker.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/worker/**"
+      - "packages/math/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/worker-docker.yml"
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: apps/worker/Dockerfile
+      - name: Test Build (Dry Run)
+        run: docker build -t worker-test -f apps/worker/Dockerfile . --target base
+
+  build-and-push:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login to Registry
+        uses: docker/login-action@v3
+        with:
+          registry: registry.reelfreakz.com
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Build and Push
+        run: |
+          IMAGE_NAME=registry.reelfreakz.com/worker
+          COMMIT_SHA=${{ github.sha }}
+          docker build \
+            -t $IMAGE_NAME:latest \
+            -t $IMAGE_NAME:$COMMIT_SHA \
+            -f apps/worker/Dockerfile .
+          docker push $IMAGE_NAME:latest
+          docker push $IMAGE_NAME:$COMMIT_SHA
+      - name: Cleanup local images
+        run: |
+          IMAGE_NAME=registry.reelfreakz.com/worker
+          COMMIT_SHA=${{ github.sha }}
+          docker rmi $IMAGE_NAME:latest $IMAGE_NAME:$COMMIT_SHA

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ To use the shared configuration in a new app:
 
 ### 2026-02-01
 
+- **feat**: Add worker docker CI/CD workflow with commit SHA tagging
 - **ci**: Remove Convex secrets from CI workflow as generated files are now checked into the repo
 - **feat**: Add GitHub Action for automated blog deployment to Cloudflare Pages
 - **feat**: Add CI/CD workflow for notebook deployment

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -25,6 +25,10 @@ Enjoy automating with our Worker! 😊
 
 ## Changelog
 
+### 2026-02-01
+
+- **feat**: Add worker docker CI/CD workflow with commit SHA tagging
+
 ### 2026-01-18
 
 - **ci**: Add GitHub Actions workflow for worker integration tests


### PR DESCRIPTION
## Summary
This PR adds a GitHub Action workflow for the worker app that:
1. Lints the Dockerfile on pull requests.
2. Performs a dry-run build on pull requests.
3. Builds and pushes the Docker image to `registry.reelfreakz.com` on merges to `main`.
4. Tags the image with both `latest` and the full commit SHA, as requested.

## Key Changes
- Created `.github/workflows/worker-docker.yml`.
- Added image tagging with `github.sha`.
- Updated root and worker READMEs with changelog entries.

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Docker image building and deployment workflow with validation on pull requests and automatic publishing to registry with commit SHA tagging.

* **Chores**
  * Updated project documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->