### PR TITLE
ci: remove pull_request trigger from notebook-deploy.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
 
   deploy-notebook:
     needs: format
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: self-hosted
     steps:
       - name: Checkout code

--- a/.github/workflows/notebook-deploy.yml
+++ b/.github/workflows/notebook-deploy.yml
@@ -6,15 +6,10 @@ on:
     paths:
       - 'apps/notebook/**'
       - '.github/workflows/notebook-deploy.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'apps/notebook/**'
-      - '.github/workflows/notebook-deploy.yml'
 
 jobs:
   deploy:
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+    if: github.event_name == 'push'
     runs-on: self-hosted
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ To use the shared configuration in a new app:
 
 ### 2026-02-01
 
+- **ci**: Remove pull_request trigger from notebook-deploy.yml to prevent unnecessary runs on PRs
 - **fix**: Rename notebook deployment script and update CI/CD workflow to resolve `ERR_PNPM_INVALID_DEPLOY_TARGET`
 - **chore**: Remove Docker Compose files, Caddy configuration, and associated scripts
 - **feat**: Add worker docker CI/CD workflow with commit SHA tagging


### PR DESCRIPTION
## Summary
This PR removes the `pull_request` trigger from the notebook deployment workflow. The workflow was running unnecessarily on PRs, even though deployment should only happen after merging to `main`.

## Key Changes
- Removed `pull_request` event from `.github/workflows/notebook-deploy.yml`.
- Simplified the `if` condition for the `deploy` job to only check for `push` events.
- Updated `README.md` changelog.

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated notebook deployment workflow to trigger only on push events, removing pull request-based execution.

* **Documentation**
  * Updated changelog to document workflow modification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->