### PR TITLE
ci: extract test-worker job to separate workflow with path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,42 +78,6 @@ jobs:
       - name: Run lint check
         run: pnpm lint
 
-  test-worker:
-    needs: lint
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
-    runs-on: self-hosted
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.0.0
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-store-${{ runner.os }}-
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Run worker integration tests
-        run: pnpm test:worker
-
   deploy-notebook:
     needs: format
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/worker-test.yml
+++ b/.github/workflows/worker-test.yml
@@ -1,0 +1,53 @@
+name: Worker Test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/worker/**'
+      - 'packages/math/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/worker-test.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/worker/**'
+      - 'packages/math/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/worker-test.yml'
+
+jobs:
+  test-worker:
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+    runs-on: self-hosted
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run worker integration tests
+        run: pnpm test:worker

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ To use the shared configuration in a new app:
 ### 2026-02-01
 
 - **ci**: Remove pull_request trigger from notebook-deploy.yml to prevent unnecessary runs on PRs
+- **ci**: Extract `test-worker` job to a separate workflow with path filters to optimize CI runs
 - **fix**: Rename notebook deployment script and update CI/CD workflow to resolve `ERR_PNPM_INVALID_DEPLOY_TARGET`
 - **chore**: Remove Docker Compose files, Caddy configuration, and associated scripts
 - **feat**: Add worker docker CI/CD workflow with commit SHA tagging


### PR DESCRIPTION
## Summary
This PR optimizes the CI pipeline by extracting the `test-worker` job from the main `ci.yml` workflow into its own dedicated workflow (`worker-test.yml`). 

## Key Changes
- Created `.github/workflows/worker-test.yml` with specific `paths` filters to only run when worker-related files or the workflow itself are modified.
- Removed the `test-worker` job from `.github/workflows/ci.yml` to prevent it from running unnecessarily on every PR.
- Updated `README.md` changelog.

## Testing
- Validated workflow syntax.
- Verified that `pnpm lint` and `pnpm format` pass at the root.

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflows by extracting worker tests into a separate workflow with path filters, reducing unnecessary CI runs while maintaining test coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->